### PR TITLE
Added SSL configurations

### DIFF
--- a/SampleService/AppConfig.cs
+++ b/SampleService/AppConfig.cs
@@ -6,5 +6,7 @@ namespace SampleService
         public string VirtualHost { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public bool SSLActive { get; set; }
+        public string SSLThumbprint { get; set; }
     }
 }

--- a/SampleService/Program.cs
+++ b/SampleService/Program.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using MassTransit;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +17,8 @@ namespace SampleService
 {
     class Program
     {
+        public static AppConfig AppConfig { get; set; }
+
         static async Task Main(string[] args)
         {
             var builder = new HostBuilder()
@@ -48,18 +55,55 @@ namespace SampleService
 
         static IBusControl ConfigureBus(IServiceProvider provider)
         {
-            var options = provider.GetRequiredService<IOptions<AppConfig>>().Value;
+            AppConfig = provider.GetRequiredService<IOptions<AppConfig>>().Value;
+
+            X509Certificate2 x509Certificate2 = null;
+
+            X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            store.Open(OpenFlags.ReadOnly);
+
+            try
+            {
+                X509Certificate2Collection certificatesInStore = store.Certificates;
+
+                x509Certificate2 = certificatesInStore.OfType<X509Certificate2>()
+                    .FirstOrDefault(cert => cert.Thumbprint?.ToLower() == AppConfig.SSLThumbprint?.ToLower());
+            }
+            finally
+            {
+                store.Close();
+            }
 
             return Bus.Factory.CreateUsingRabbitMq(cfg =>
             {
-                var host = cfg.Host(options.Host, options.VirtualHost, h =>
+                var host = cfg.Host(AppConfig.Host, AppConfig.VirtualHost, h =>
                 {
-                    h.Username(options.Username);
-                    h.Password(options.Password);
+                    h.Username(AppConfig.Username);
+                    h.Password(AppConfig.Password);
+
+                    if (AppConfig.SSLActive)
+                    {
+                        h.UseSsl(ssl =>
+                        {
+                            ssl.ServerName = Dns.GetHostName();
+                            ssl.AllowPolicyErrors(SslPolicyErrors.RemoteCertificateNameMismatch);
+                            ssl.Certificate = x509Certificate2;
+                            ssl.Protocol = SslProtocols.Tls12;
+                            ssl.CertificateSelectionCallback = CertificateSelectionCallback;
+                        });
+                    }
                 });
 
                 cfg.ConfigureEndpoints(provider);
             });
+        }
+
+        private static X509Certificate CertificateSelectionCallback(object sender, string targethost, X509CertificateCollection localcertificates, X509Certificate remotecertificate, string[] acceptableissuers)
+        {
+            var serverCertificate = localcertificates.OfType<X509Certificate2>()
+                                    .FirstOrDefault(cert => cert.Thumbprint.ToLower() == AppConfig.SSLThumbprint.ToLower());
+
+            return serverCertificate ?? throw new Exception("Wrong certificate");
         }
     }
 }

--- a/SampleService/appsettings.json
+++ b/SampleService/appsettings.json
@@ -8,6 +8,8 @@
     "Host": "localhost",
     "VirtualHost": "/",
     "Username": "guest",
-    "Password": "guest"
+    "Password": "guest",
+    "SSLActive": false,
+    "SSLThumbprint": "a7a75205438e0b3697be97adc6ebbea715bf16b4"
   }
 }


### PR DESCRIPTION
In the appsettings added:
- SSLActive 
- SSLThumbprint 

All certificates are stored in the certificate store.

When SSLActive is true we enable 
```
 h.UseSsl(ssl =>
                        {
                            ssl.ServerName = Dns.GetHostName();
                            ssl.AllowPolicyErrors(SslPolicyErrors.RemoteCertificateNameMismatch);
                            ssl.Certificate = x509Certificate2;
                            ssl.Protocol = SslProtocols.Tls12;
                            ssl.CertificateSelectionCallback = CertificateSelectionCallback;
                        });
```